### PR TITLE
Let you set mob keywords

### DIFF
--- a/Search_and_Destroy.xml
+++ b/Search_and_Destroy.xml
@@ -58,7 +58,7 @@
 
 	PLUGIN_VERSION  = GetPluginInfo(GetPluginID(), 19)
 	PLUGIN_NAME 	= GetPluginInfo(GetPluginID(), 1)
-	SCHEMA_VERSION  = 1
+	SCHEMA_VERSION  = 2
 
 	local current_sd_version 		= "Search & Destroy v" .. PLUGIN_VERSION
 	local plugin_id_gmcp_handler 	= "3e7dedbe37e44942dd46d264"		-- easier to remember the var names than the plugin id's
@@ -71,7 +71,7 @@
 	local db_file_1
 	local db_file_2
 	local mapper_db_file = GetInfo(66)..WorldName()..".db"	-- typically aardwolf.db, normally found in main Mushclient folder
-	--local sd_db_file = GetPluginInfo(GetPluginID(), 20) .. "sddb.db"	-- sddb.db, normally found in MUSHClient/worlds/plugins folder
+	local snd_db_file = GetInfo(66) .. "/SnDdb.db"
 
 -- [[ Current, previous room data GMCP_room_info ]]
 	local current_room  = { rmid = "-1", arid = "-1", maze = "no", exits = {} }
@@ -272,6 +272,11 @@
 			area_index_process()
 		end
 
+		if current_version < 2 then
+			create_mob_keywords_table(db)
+			strip_mobs_table(db)
+		end
+
 		db:execute(string.format("PRAGMA user_version = %i;", SCHEMA_VERSION))
 
 		db:close_vm()
@@ -280,12 +285,12 @@
 	function create_initial_tables(db)
 		local db_tables = {}
 		local query = "SELECT name FROM sqlite_master WHERE type='table'"
+		local create_tables = {}
 
 		for row in db:nrows(query) do
 			db_tables[row.name] = true
 		end
 
-		create_tables = {}
 		if not db_tables['mobs'] then
 			Note("Creating table 'mobs'")
 			table.insert(create_tables, [[
@@ -320,6 +325,37 @@
 		end
 	end
 
+	function create_mob_keywords_table(db)
+		Note("Creating mob aliases database table")
+		db:execute([[
+			CREATE TABLE IF NOT EXISTS mob_keyword_exceptions (
+				area_name	TEXT NOT NULL,
+				mob_name	TEXT NOT NULL,
+				keyword		TEXT NOT NULL,
+				UNIQUE(area_name, mob_name)
+			);
+		]])
+		populate_mob_keyword_table(db)
+	end
+
+	function strip_mobs_table(db)
+		Note("Updating mobs table")
+		db:execute([[
+			BEGIN TRANSACTION;
+			ALTER TABLE mobs RENAME TO old_mobs;
+			CREATE TABLE mobs (
+				mob 		TEXT NOT NULL COLLATE NOCASE,
+				room 		TEXT NOT NULL COLLATE NOCASE,
+				roomid 		INTEGER NOT NULL,
+				zone 		TEXT NOT NULL,
+				count 		INTEGER NOT NULL DEFAULT 0,
+				UNIQUE(mob, roomid));
+			INSERT INTO mobs SELECT mob COLLATE NOCASE, room COLLATE NOCASE, roomid, zone, SUM(count) as count FROM old_mobs GROUP BY mob COLLATE NOCASE, roomid;
+			DROP TABLE old_mobs;
+			COMMIT;
+		]])
+	end
+
 	local init_called = 0
 	function init_plugin()
 		if not IsConnected() then return end
@@ -335,6 +371,12 @@
 			load_saved_table_data()
 			send_gmcp_packet("config noexp")
 		end
+	end
+
+	-- Expecting an array of operations
+	function execute_in_transaction(db, operations)
+		query = "BEGIN TRANSACTION;" .. table.concat(operations, "") .. "COMMIT;"
+		db:exec(query)
 	end
 
 -- [[ Lookup table:  Area start room, noquest true/false, vidblain areas ]]
@@ -1051,7 +1093,13 @@ end
 	local gmkw_exceptions = {
 		["aardington"]	= { ["a very large portrait"]				= { kw="large port"			}, },
 
-		["anthrox"]		= { ["the little white rabbit"]				= { kw="rabb"				}, },
+		["alehouse"]		= { ["a dancing male patron"]				= { kw="dancing male"		},
+								["a dancing female patron"]				= { kw="dancing female"		},},
+
+		["anthrox"]		= { ["the little white rabbit"]				= { kw="rabb"				},
+							["the bee"]								= { kw="worker bee"			},
+							["an escaped creature"]					= { kw="prisoner creature"	},
+							['a "business" man']					= { kw="business man"	},},
 
 		["ddoom"]		= { ["a dangerous scorpion"]				= { kw="scorp"				},
 							["Lwji, the Sunrise great warrior"]		= { kw="lwji"				},
@@ -1070,6 +1118,10 @@ end
 		["fortress"]	= { ["a grizzled goblin dressed in skins"]	= { kw="grizz gobl"		 	},
 							["Blood Silk, Collector of souls, Queen of the spiders"] = { kw="silk queen" }, },
 
+		["hell"]		= { ["a scrumptious chicken pot pie"] 		= { kw="chicken pot pie"	},
+							["a yummy vegetable pot pie"] 			= { kw="vegetable pot pie"	},
+							["a yummy beef pot pie"] 				= { kw="beef pot pie"		}, },
+
 		["illoria"]		= { ["the King and Queen's Guard"]			= { kw="pers guard"			}, },
 
 		["landofoz"]	= { ["one of Dorothy's uncles"] 			= { kw="doroth uncle"		}, },
@@ -1084,7 +1136,8 @@ end
 
 		["longnight"]	= { ["Mr. Roberge"]							= { kw="car rober"			}, },
 
-		["losttime"]	= { ["T-Rex"]								= { kw="T-rex"				}, },
+		["losttime"]	= { ["T-Rex"]								= { kw="T-rex"				},
+							["Great White Shark"]					= { kw="white shark"				}, },
 
 		["manor"]		= { ["Aremata-Popua"] 						= { kw="aremata-pop"	 	},
 							["Aremata-Rorua"] 						= { kw="aremata-ror" 		}, },
@@ -1103,7 +1156,10 @@ end
 		["siege"]		= { ["a kobold eating lunch"]				= { kw="kobold eating"		},
 							["a large mole"]						= { kw="mole"				},
 							["a very large firefly"]				= { kw="larg firef"			},
-							["the fattest kobold ever"]				= { kw="fat kobold"			}, },
+							["the fattest kobold ever"]				= { kw="fat kobold"			},
+							["an oddly tall and clean kobold"]		= { kw="tall kobold"			}, },
+
+		["snuckles"]	= { ["the snuckle"]							= { kw="male snuckle"		}, },
 
 		["sohtwo"]      = { ["An evil form of Sagen"]               = { kw="notcarlsagen"        },
 							["Angelic Demonspawn"]                  = { kw="angelic"             },
@@ -1198,18 +1254,125 @@ end
 
 		["zoo"]			= { ["a black-footed pine marten"]			= { kw="pine marte"			}, }, }
 
+	function populate_mob_keyword_table(db)
+		local inserts = {}
+		for area, mob_keywords in pairs(gmkw_exceptions) do
+			for mob_name, keyword in pairs(mob_keywords) do
+				local str = string.format("INSERT INTO mob_keyword_exceptions VALUES (%s,%s,%s);", fixsql(area), fixsql(mob_name), fixsql(keyword["kw"]))
+				table.insert(inserts, str)
+			end
+		end
+		execute_in_transaction(db, inserts)
+		db:execute(table.concat(inserts, ""))
+	end
+
+	function set_mob_keyword(name, line, wildcards)
+		local current_area = current_room.arid
+		local area_list = {}
+		local db = assert(sqlite3.open(mapper_db_file))
+		local i
+		local area
+		local mob_name
+		local keyword
+
+		for row in db:nrows("SELECT uid FROM areas ORDER BY uid ASC") do
+			area_list[row.uid] = row.uid
+		end
+
+		area = utils.choose("Area", "Please choose the mob's area.", area_list, current_area)
+		if not area then return end
+
+		function require_input(input)
+			return #Trim(input) > 0
+		end
+
+		mob_name = utils.inputbox("Enter the mob's full name.\nFor example: a yummy beef pot pie", "Enter mob name", nil, nil, 0, {validate = require_input})
+		if not mob_name then return end
+		mob_name = Trim(mob_name)
+
+		keyword = utils.inputbox(string.format("Enter the new keyword for '%s'.\nFor example: beef pie", mob_name), "Enter new keyword", nil, nil, 0, {validate = require_input})
+		if not keyword then return end
+		keyword = Trim(keyword)
+
+		if save_mob_keyword_keyword(area, mob_name, keyword) then
+			if full_mob_name == mob_name then
+				short_mob_name = keyword
+			end
+			update_main_target_list_keyword(area, mob_name, keyword)
+		end
+	end
+
+	function set_current_mob_keyword(name, line, wildcards)
+		local keyword = Trim(wildcards.keyword)
+		local area
+
+		if (short_mob_name == nil) or (short_mob_name == "") or (short_mob_name == "-1") or (short_mob_name == -1) then
+			ColourNote("#FF5000", "", "\nSearch and Destroy: 'kw' has no target.  Use 'ht', 'qw', or 'xcp' to select a target, or use 'xset kw' with no arguments.")
+		else
+			if quest_target.mob and quest_target.mob == full_mob_name then
+				area = quest_target.arid
+			end
+
+			if not area then
+				area = main_target_list[xcp_index].arid
+			end
+
+			if not area then
+				ColourNote("#FF5000", "", "\nSearch and Destroy: Target's area could not be identified. Try visiting its area and trying again.")
+				return
+			end
+
+			if save_mob_keyword_keyword(area, full_mob_name, keyword) then
+				short_mob_name = keyword
+				update_main_target_list_keyword(area, full_mob_name, keyword)
+			end
+		end
+	end
+
+	function update_main_target_list_keyword(area, mob_name, keyword)
+		for i, mobdesc in ipairs(main_target_list) do
+			if area == mobdesc.arid and mob_name == mobdesc.mob then
+				mobdesc.kw = keyword
+			end
+		end
+	end
+
+	function save_mob_keyword_keyword(area, mob_name, keyword)
+		local found_area = false
+		local query
+
+		local db = assert(sqlite3.open(snd_db_file))
+		query = string.format("INSERT OR REPLACE INTO mob_keyword_exceptions VALUES (%s,%s,%s);", fixsql(area), fixsql(mob_name), fixsql(keyword))
+		db:exec(query)
+		db:close_vm()
+
+		ColourNote(
+			"", "", "Updated keyword for ",
+			"green", "", mob_name,
+			"", "", " to ",
+			"green", "", keyword,
+			"", "", " in area ",
+			"green", "", area .. "\n"
+		)
+		return true
+	end
+
 	function gmkw(s, a)	-- guess mob keywords
 		if not s then return "" end
 		local ri = current_room
 		local ar = a or ri.zone
 		local guess
-		if gmkw_exceptions[ar] then			-- Is the mob listed as a keyword exception?  if so, look up keywords from the exception table instead of guessing.
-			if gmkw_exceptions[ar][s] then
-				guess = gmkw_exceptions[ar][s].kw	-- Special thanks to Redryn for being obtuse and aggravating me enough that I added this.  Dick.
-				return guess
-			else
-				--
-			end
+
+		local db = sqlite3.open(snd_db_file)
+		query = string.format("SELECT keyword FROM mob_keyword_exceptions WHERE area_name = %s AND mob_name = %s LIMIT 1;", fixsql(ar), fixsql(s))
+		for row in db:nrows(query) do
+			guess = row.keyword
+		end
+		db:close_vm()
+
+		if guess then
+			ColourNote("", "", "Found custom keyword for ", "green", "", s, "", "", ": ", "green", "", guess)
+			return guess
 		end
 
 		local omit = gmkw_omit
@@ -2496,7 +2659,7 @@ function goto_number(name, line, wildcards)
 	end
 
 	function quick_kill(name, line, wildcards)
-		if (short_mob_name == nil) or (short_mob_name == "") or (short_mob_name == "-1") then
+		if (short_mob_name == nil) or (short_mob_name == "") or (short_mob_name == "-1") or (short_mob_name == -1) then
 			ColourNote("#FF5000", "", "\nSearch and Destroy: 'Quick-kill' has no target.  Use 'ht', 'qw', or 'xcp' to select a target.\n")
 		else
 			for command in quick_kill_command:gmatch("[%a%s%p]+[^;]?") do
@@ -4165,7 +4328,7 @@ function goto_number(name, line, wildcards)
 
 	function onHelp(name, line, wildcards)
 		local str = wildcards[1]
-		local helpFiles = {"win", "fontsize", "linespace", "speed", "vidblain", "mark", "index areas", "silent", "sort", "xm", "xmap", "roomnote", "qw", "ht", "ah", "ak|kk|qk", "qs", "xq", "noexp", "nx", "go", "xrt|xrun", "cp|gq", "xcp", "xcp mode", "ms|msearch", "mgo|mgoto", "snd migrate|mergePwar", "snd update", "snd reload", "summary"}
+		local helpFiles = {"win", "fontsize", "linespace", "speed", "vidblain", "mark", "index areas", "silent", "sort", "xm", "xmap", "roomnote", "qw", "ht", "ah", "ak|kk|qk", "qs", "xq", "noexp", "kw|keyword", "nx", "go", "xrt|xrun", "cp|gq", "xcp", "xcp mode", "ms|msearch", "mgo|mgoto", "snd migrate|mergePwar", "snd update", "snd reload", "summary"}
 
 		local headers = {"cyan", "", string.rep("-", 76) .. "\n", "darkcyan", "", "Help keywords", "antiquewhite", "", " : " .. str .. "\n", "cyan", "", string.rep("-", 76) .. "\n"}
 
@@ -4358,10 +4521,12 @@ function goto_number(name, line, wildcards)
 			Note()
 			ColourNote("antiquewhite", "", unpack({helpWrap("This will only work if the file name has not been altered from 'WinkleGold_Database.db' and that the file is located in the default plugin directory. If you have moved it or renamed it, please make sure it is located in the 'plugins' folder with the name 'WinkleGold_Database.db' and run this command again. Thank you.")}))
 
-		elseif str == "mobkey" then
-			ColourNote("yellow", "", "Syntax", "antiquewhite", "", ": xset mobkey {<short desc>} {<keyword>} <all>")
+		elseif str == "kw" or str == 'keyword' then
+			ColourNote("yellow", "", "Syntax", "antiquewhite", "", ": xset kw <mob keyword>")
 			Note()
-			ColourNote("antiquewhite", "", unpack({helpWrap("This will change the keyword to the mob based on the short description in the room you are currently in. You must use the braces to capture the information correctly. Adding the argument 'all' will change the keyword for all mobs with the same short description in the area rather than just in the room.")}))
+			ColourNote("antiquewhite", "", unpack({helpWrap("This command will change a mob's keyword so that it is properly targeted. For example, say you have a campaign target of 'a yummy beef pot pie.' By default, S&D might target 'yummy pie' which doesn't actually match. Instead, you'll want it to target 'beef pie.'")}))
+			Note()
+			ColourNote("antiquewhite", "", unpack({helpWrap("To do so, you can use 'xset kw beef pie' while it is a campaign, quest, or gquest target. Alternatively, you can use 'xset kw' with no arguments and follow the dialogs that appear.")}))
 
 		elseif str == "summary" then
 		ColourNote("yellow", "", "Commands:")
@@ -4412,6 +4577,8 @@ function goto_number(name, line, wildcards)
 		Note()
 		ColourNote("antiquewhite", "", unpack({helpWrap("xset noexp <off|#>:  Displays current setting with no argument. With argument, toggles noexp off or sets it to turn on at # exp remaining.")}))
 		Note()
+		ColourNote("antiquewhite", "", unpack({helpWrap("xset kw <mob keyword>:  Set the keyword(s) that will be used to target a particular mob.")}))
+		Note()
 		ColourNote("antiquewhite", "", unpack({helpWrap("nx<->:  Moves to the next room on the list, or the previous room with -.")}))
 		Note()
 		ColourNote("antiquewhite", "", unpack({helpWrap("go <index>:  Runs to the first room in the index, or to the index number with argument.")}))
@@ -4448,96 +4615,109 @@ function goto_number(name, line, wildcards)
 		Execute(GetAlphaOption("script_prefix") .. "DoAfterSpecial(1, \"ReloadPlugin('" .. GetPluginID() .. "')\", sendto.script)")
 	end
 
+	function copyPwarWarn()
+		ColourNote("cyan", "", "Are you sure you want to do this? It will wipe out your existing mob and keyword data. Type ",
+			"lime", "", "snd migrate confirm",
+			"cyan", "", " to migrate data from your pwar database.")
+	end
+
 	function copyPwarDB()
+		local success, err = pcall(rawCopyPwarDB)
 
-		os.remove(GetInfo(66) .. "/SnDdb.db")
+		if success then
+			ColourNote("cyan", "", "Finished migrating! You can now resume play!")
+		else
+			ColourNote("tomato", "", err)
+		end
+	end
 
-		migrate_database()
-
+	function rawCopyPwarDB()
 		local f = io.open(GetInfo(60) .. "WinkleGold_Database.db", "r")
 
 		if not f then
-			ColourNote("tomato", "", "To start migration process, please locate the file 'WinkleGold_Database.db' and move it to the plugins folder. Then try again.")
+			error("To start migration process, please locate the file 'WinkleGold_Database.db' and move it to the plugins folder. Then try again.")
 		else
+			ColourNote("cyan", "", "Now rebuilding the database with data from Pwar's Search & Destroy.")
+
+			os.remove(snd_db_file)
+			migrate_database()
+
 			f:close()
-			PwarDb = sqlite3.open(GetInfo(60) .. "/WinkleGold_Database.db")
-			mapperDb = sqlite3.open(GetInfo(66) .. "Aardwolf.db")
-			SnDdb = sqlite3.open(GetInfo(66) .. "/SnDdb.db")
-			migrateTable = {}
 
-			ColourNote("cyan", "", "Now copying data from Pwar's database. Go make a sandwich or something while this completes the process. It may take a few minutes. Your client will likely freeze during this operation. You have 10 seconds to get to somewhere safe first!")
+			local PwarDb = assert(sqlite3.open(GetInfo(60) .. "/WinkleGold_Database.db"))
+			local mapperDb = assert(sqlite3.open(GetInfo(66) .. "Aardwolf.db"))
+			local SnDdb = assert(sqlite3.open(GetInfo(66) .. "/SnDdb.db"))
+			local roomsById = {}
+			local roomsToLookup = {}
+			local migrateTable = {}
+			local insertStatements = {}
+			local batch_size = 10000
+			local err
 
-			for i = 1,10 do
-				DoAfterSpecial(i, "print('" .. 10-i .. " seconds left...')", 12)
+			local mobQuery = "SELECT roomid, mobname, sum(freq) as count FROM mobs GROUP BY roomid, mobname"
+
+			for row in PwarDb:nrows(mobQuery) do
+				table.insert(roomsToLookup, row.roomid)
+				table.insert(migrateTable, {roomid =  row.roomid,  mob = row.mobname, count = row.count})
 			end
 
-			DoAfterSpecial(10, [[
-			local sqlQuery = "SELECT roomid, mobname, freq FROM mobs"
+			roomQuery = string.format("SELECT uid, area, name FROM rooms WHERE uid IN (%s)", table.concat(roomsToLookup, ","))
 
-			for a in PwarDb:rows(sqlQuery) do
-				zoneQuery = "SELECT area, name FROM rooms WHERE uid = " .. a[1]
-				for b in mapperDb:rows(zoneQuery) do
-					table.insert(migrateTable, {roomid = a[1],  mob = a[2], count = a[3], room = b[2], zone = b[1], keyword = ""})
+			for row in mapperDb:nrows(roomQuery) do
+				roomsById[tostring(row.uid)] = {area = row.area, name = row.name}
+			end
+			mapperDb:close()
+
+			for i, mob in ipairs(migrateTable) do
+				room = roomsById[tostring(mob.roomid)]
+				if room then
+					table.insert(insertStatements, string.format("INSERT INTO mobs (mob,room,roomid,zone,count) VALUES (%s,%s,%s,%s,%i);", fixsql(mob.mob), fixsql(room.name), mob.roomid, fixsql(room.area), mob.count))
+
+					if #insertStatements > batch_size then
+						execute_in_transaction(SnDdb, insertStatements)
+						if SnDdb:errcode() > 0 then
+							err = SnDdb:error_message()
+							SnDdb:close()
+							PwarDb:close()
+							error("Encountered an error during migration: " .. err)
+						end
+						insertStatements = }
+					end
 				end
 			end
 
-			mapperDb:close()
-
 			local keyQuery = "SELECT mobname, areaid, subname FROM mobsubs"
 
-			for a in PwarDb:rows(keyQuery) do
-				for i,v in ipairs(migrateTable) do
-					if v.mob:upper() == a[1]:upper() and v.zone:upper() == a[2]:upper() then
-						v.keyword = a[3]
+			for row in PwarDb:nrows(keyQuery) do
+				table.insert(insertStatements, string.format("INSERT OR REPLACE INTO mob_keyword_exceptions (area_name,mob_name,keyword) VALUES (%s,%s,%s);", fixsql(row.areaid), fixsql(row.mobname), fixsql(row.subname)))
+				if #insertStatements > batch_size then
+					execute_in_transaction(SnDdb, insertStatements)
+					if SnDdb:errcode() > 0 then
+						err = SnDdb:error_message()
+						SnDdb:close()
+						PwarDb:close()
+						error("Encountered an error during migration: " .. err)
 					end
+
+					insertStatements = {}
 				end
 			end
 
 			PwarDb:close()
 
-			for _,v in ipairs(migrateTable) do
-				local sqlInsert = "INSERT INTO mobs VALUES ('" .. v.mob .. "','" .. v.room .. "'," .. tonumber(v.roomid) .. ",'" .. v.zone .. "'," .. v.count .. ",'" .. v.keyword .."')"
-
-				SnDdb:exec(sqlInsert)
+			execute_in_transaction(SnDdb, insertStatements)
+			if SnDdb:errcode() > 0 then
+				err = SnDdb:error_message()
+				SnDdb:close()
+				error("Encountered an error during migration: " .. err)
 			end
 
-			SnDdb:exec("DELETE FROM mobs WHERE rowid NOT IN (SELECT min(rowid) FROM mobs GROUP BY mobname, roomid)")
-
 			SnDdb:close()
-
-			ColourNote("cyan", "", "Finished migrating! You can now resume play!")]], 12)
-		end
-	end
-
-	function mobKey(name, line, wildcards)
-		if wildcards[1] == "" then
-			ColourNote("cyan", "", "The correct syntax is: ", "antiquewhite", "", "xset mobkey {short name} {keyword} <all|area keyword>")
-		else
-			local short, keyword, span, sqlAppend, updateAppend = wildcards[1], wildcards[2], wildcards[3] or "", "", "room only."
-
-			if span:upper() == "ALL" then
-				sqlAppend = " AND zone = " .. gmcp("room.info.zone")
-				updateAppend = "entire zone."
-			elseif span and span ~= "" then
-				sqlAppend = " AND zone = " .. span
-				updateAppend = "in zone " .. span
-			end
-
-			SnDdb = sqlite3.open(GetInfo(66) .. "/SnDdb.db")
-
-			local sqlQuery = "UPDATE mobs SET keyword = '" .. keyword .. "' WHERE mob LIKE '" .. short .. "'" .. sqlAppend
-
-			SnDdb:exec(sqlQuery)
-
-			ColourNote("cyan", "", "Updated " .. short .. " keyword to " .. keyword .. " in " .. updateAppend)
-
-			SnDdb:close()
-
 		end
 	end
 
 	function mobLookup (name, location, level, exact)
-		SnDdb = sqlite3.open(GetInfo(66) .. "/SnDdb.db")
+		SnDdb = sqlite3.open(snd_db_file)
 
 		if exact ~= "" or exact ~= nil then exact = false end
 
@@ -4586,7 +4766,7 @@ function goto_number(name, line, wildcards)
 
 	function showResults(query, msg)
 
-		SnDdb = sqlite3.open(GetInfo(66) .. "/SnDdb.db")
+		SnDdb = sqlite3.open(snd_db_file)
 		mshow = {}
 		local searchMsg, failure = msg, "No matches found!"
 
@@ -4708,29 +4888,16 @@ function goto_number(name, line, wildcards)
 	function findMobs(name, room)
 
 		if #name > 1 then
-			SnDdb = sqlite3.open(GetInfo(66) .. "/SnDdb.db")
-
-			name = name:gsub("'", "''")
-
-
 			local rname, zname = strip_colours(gmcp("room.info.name")), gmcp("room.info.zone")
-			local sqlQuery = "SELECT * FROM mobs WHERE mob LIKE '" .. name:gsub("'", "''") .. "' AND roomid = " .. room
-			local sqlUpdate = "UPDATE mobs SET Count = Count + 1 WHERE mob LIKE '" .. name:gsub("'", "''") .. "' AND roomid = " .. room
-			local sqlInsert = "INSERT INTO mobs VALUES ('" .. name:gsub("'", "''") .. "','" .. rname:gsub("'", "''") .. "'," .. room .. ",'" .. zname .. "',1,'" .. gmkw(name) .. "')"
 
-			local mobFound = false
+			local update = {
+				string.format("INSERT OR IGNORE INTO mobs (mob,room,roomid,zone) VALUES (%s,%s,%i,%s);", fixsql(name), fixsql(rname), tonumber(room), fixsql(zname)),
+				string.format("UPDATE mobs SET Count = Count + 1 WHERE mob = %s AND roomid = %i;", fixsql(name), tonumber(room)),
+			}
 
-			for m in SnDdb:rows(sqlQuery) do
-				if m[1] then
-					mobFound = true
-				end
-			end
+			SnDdb = sqlite3.open(snd_db_file)
 
-			if mobFound then
-				SnDdb:exec(sqlUpdate)
-			else
-				SnDdb:exec(sqlInsert)
-			end
+			execute_in_transaction(SnDdb, update)
 
 			SnDdb:close_vm()
 		else
@@ -5328,6 +5495,14 @@ function goto_number(name, line, wildcards)
 			script=""
 			enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12" > </alias>
 
+	<alias	match="^xset kw$"
+		script="set_mob_keyword"
+		enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12" > </alias>
+
+	<alias	match="^xset kw (?<keyword>.+)$"
+		script="set_current_mob_keyword"
+		enabled="y" regexp="y" sequence="100" ignore_case="y" send_to="12" > </alias>
+
 <!-- xset window commands -->
 	<alias	match="^xset fontsize( (?<size>[0-9]+))?$"
 			script="xset_font_size"
@@ -5417,6 +5592,15 @@ function goto_number(name, line, wildcards)
 
   <alias
 	match="^(snd migrate|mergePwar)$"
+	enabled="y"
+	regexp="y"
+	script="copyPwarWarn"
+	sequence="100"
+  >
+	</alias>
+
+  <alias
+	match="^(snd migrate|mergePwar) confirm$"
 	enabled="y"
 	regexp="y"
 	script="copyPwarDB"


### PR DESCRIPTION
Sometimes Search & Destroy picks the wrong name for a mob to target and you end up having to target it manually. It contains a list of alternate names to use for certain mobs, but it is not perfect and will be missing some as new areas are added. This change lets you change mob keywords on the fly in several ways, and stores them in a database so when you encounter them again, you'll target the correct thing.

How to use:
`xset kw`
This will open a series of dialog boxes where you can specify the area of the mob, the full name, and the new keyword.

If you have a current quest, campaign, or gquest target, you can specify the keyword directly from the command line:
```
xset kw beef pie
```
It will pick up the area and full mob name automatically.